### PR TITLE
Fixup example main function for trace_parser

### DIFF
--- a/src/utils/trace_parser.py
+++ b/src/utils/trace_parser.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -6,7 +7,7 @@ from config.project_config import (
     DATA_DIRECTORY,
     DEFAULT_TRACE_FILE,
     ROOT_DIR,
-    parse_arguments,
+    config,
 )
 
 
@@ -149,7 +150,9 @@ class TraceFileParser:
 # Small test for parser
 def main():
     """Main entry point for the trace file parser utility"""
-    args = parse_arguments()
+    config.initialize(sys.argv[1:])
+
+    args = config.get_args()
     try:
         with TraceFileParser(args.file) as parser:
             while True:


### PR DESCRIPTION
The small example `main` function from the trace parser needs to use the new `config` instance to access `args`.

I think we might be at a point where we could just remove the example, but I thought I'd put up a fix first to see if we want to keep it.