### PR TITLE
Feature/cache set

### DIFF
--- a/src/cache/cache_set.py
+++ b/src/cache/cache_set.py
@@ -1,0 +1,224 @@
+from datalasses import dataclass
+from typing import Optional, Tuple
+import math
+
+class MESIState(Enum):
+    """
+    Cache coherency states for the MESI protocol (2-bit encoding):
+    
+    M (Modified)  - Line is dirty and exclusive to this cache (0b11)
+    E (Exclusive) - Line is clean and exclusive to this cache (0b10)
+    S (Shared)    - Line is clean and may exist in other caches (0b01)
+    I (Invalid)   - Line is invalid/unused (0b00)
+
+    Source :  
+        - https://en.wikipedia.org/wiki/MESI_protocol
+    """
+    INVALID = 0     # 0b00
+    SHARED = 1      # 0b01
+    EXCLUSIVE = 2   # 0b10
+    MODIFIED = 3    # 0b11
+
+    @property
+    def bits(self) -> int:
+        """Returns the 2-bit encoding of the state"""
+        return self.value
+
+@dataclass
+class CacheLine:
+    """
+    Represents a cache line with MESI protocol state tracking and L1 inclusion status.
+    """
+    tag: Optional[int] = None
+    mesi_state: MESIState = MESIState.INVALID
+    in_l1: bool = False     # For cache coherency
+
+    def is_invalid(self) -> bool:
+        """Check if line is in Invalid state"""
+        return self.mesi_state == MESIState.INVALID
+    
+    def is_shared(self) -> bool:
+        """Check if line is in Shared state"""
+        return self.mesi_state == MESIState.SHARED
+    
+    def is_exclusive(self) -> bool:
+        """Check if line is in Exclusive state"""
+        return self.mesi_state == MESIState.EXCLUSIVE
+    
+    def is_modified(self) -> bool:
+        """Check if line is in Modified state"""
+        return self.mesi_state == MESIState.MODIFIED
+    
+    def set_invalid(self):
+        """Set line to Invalid state"""
+        self.mesi_state = MESIState.INVALID
+        
+    def set_shared(self):
+        """Set line to Shared state"""
+        self.mesi_state = MESIState.SHARED
+        
+    def set_exclusive(self):
+        """Set line to Exclusive state"""
+        self.mesi_state = MESIState.EXCLUSIVE
+        
+    def set_modified(self):
+        """Set line to Modified state"""
+        self.mesi_state = MESIState.MODIFIED
+    
+    def get_state_bits(self) -> int:
+        """Returns the 2-bit encoding of the current MESI state"""
+        return self.mesi_state.bits
+
+    def __str__(self) -> str:
+        """String representation of the cache line"""
+        return f"Tag={hex(self.tag) if self.tag is not None else 'None'}, " \
+               f"State={self.mesi_state.name}, " \
+               f"In L1={self.in_l1}"
+
+
+class CacheSet:
+    """
+    Implements an N-way set associative cache set with MESI protocol and PLRU replacement.
+    Default configuration is 16-way, with supported ways from 1 to 32 (must be power of 2).
+    """
+    MAX_WAYS = 32  # Maximum supported ways
+    MIN_WAYS = 1   # Minimum supported ways
+
+    def __init__(self, num_ways: int = 16):
+        # Validate num_ways
+        if not isinstance(num_ways, int):
+            raise TypeError("Number of ways must be an integer")
+        if num_ways < self.MIN_WAYS or num_ways > self.MAX_WAYS:
+            raise ValueError(f"Number of ways must be between {self.MIN_WAYS} and {self.MAX_WAYS}")
+        if not (num_ways & (num_ways - 1) == 0):
+            raise ValueError("Number of ways must be a power of 2")
+        
+        self.num_ways = num_ways
+        self.tree_levels = int(math.log2(num_ways))  # Levels in PLRU tree
+        
+        # Initialize cache lines
+        self.ways = [CacheLine() for _ in range(num_ways)]
+        
+        # Initialize PLRU state - only need (num_ways - 1) bits for tree
+        self.state = 0
+        
+    def __get_parent(self, node: int) -> int:
+        """Helper method for PLRU tree traversal"""
+        return (node - 1) // 2
+
+    def __update_plru(self, way_index: int) -> None:
+        """
+        Update PLRU state when a way is accessed.
+        """
+        if way_index >= self.num_ways:
+            raise ValueError(f"Way index {way_index} out of range for {self.num_ways}-way set")
+            
+        # PLRU bits are updated with a bottom up tree traversal
+        leaf_node = way_index + (self.num_ways -1)  # Convert way index to a leaf_node number
+        node = self.get_parent(leaf_node)           # Use leaf node to get first internal node (i.e. PLRU bit)
+
+        if way_index % 2 == 0:                      # Left child accessed
+            self.state &= ~(1 << node)              # Clear node's bit
+        else:                                       # Right child accessed
+            self.state |= (1 << node)               # Set node's bit
+        
+        while node > 0:
+            parent = self.get_parent(node)
+            if node == 2 * parent + 1:              # Current node is left child
+                self.state &= ~(1 << parent)        # Clear parent's bit
+            else:                                   # Current node is right child
+                self.state |= (1 << parent)         # Set parent's bit
+            node = parent
+    
+    def __get_plru_victim(self) -> int:
+        """
+        Find the way to replace according to PLRU policy.
+        Returns: 
+            - Way index [0 - n_ways]
+        """
+        node = 0
+        for _ in range(self.tree_levels):           
+            if self.state & (1 << node):
+                node = 2 * node + 1  # Go left
+            else:
+                node = 2 * node + 2  # Go right
+        # Calculate leaf node index based on number of ways
+        return node - (self.num_ways - 1)
+    
+    def __find_line(self, tag: int) -> Tuple[Optional[CacheLine], Optional[int]]:
+        """Find a cache line by tag. Returns (line, way_index) or (None, None)"""
+        for i, line in enumerate(self.ways):
+            if not line.is_invalid() and line.tag == tag:
+                return line, i
+        return None, None
+
+    def read(self, tag: int) -> bool:
+        """
+        Simulates a read request to a cache set. If tag is found returns valid, else
+        a cacheline fill is requested. Upon a valid access plru bits are updated. 
+        """
+        line, way_index = self.__find_line(tag)
+        if line is not None:  # Hit
+            self.__update_plru(way_index)
+            return True
+        return False          # Miss
+
+    def write(self, tag: int) -> bool:
+        """
+        Simulates a cache write request to a set. Write allocate policy is employed so any 
+        write misses require cache to allocate line. 
+        """
+        line, way_index = self.__find_line(tag)
+        if line is not None:  # Hit
+            self.__update_plru(way_index)
+            
+            return True
+        return False          # Miss
+
+    def allocate(self, tag: int, state: MESIState = MESIState.EXCLUSIVE) -> int:
+        """
+        Allocate a new cache line. First searches for invalid lines,
+        if none found uses PLRU to select victim.
+    
+        Args:
+            tag: Tag to be stored in the cache line
+            state: Initial MESI state (default Exclusive for new allocations)
+        
+        Returns: 
+         way_index where line was allocated
+        """
+        # First check for invalid lines
+        for way_index, line in enumerate(self.ways):
+            if line.is_invalid():
+                # Found an invalid line, use it
+                line.tag = tag
+                line.mesi_state = state
+                self.__update_plru(way_index)
+                return way_index
+            
+        # No invalid lines found, use PLRU to select victim
+        victim_way = self.__get_plru_victim()
+        victim_line = self.ways[victim_way]
+    
+        # Set up new line
+        victim_line.tag = tag
+        victim_line.mesi_state = state
+        victim_line.in_l1 = False  # Reset L1 inclusion status
+    
+        self.__update_plru(victim_way)
+    return victim_way
+
+
+    def __str__(self) -> str:
+        """String representation showing valid lines"""
+        output = []
+        for i, line in enumerate(self.ways):
+            if line['valid']:
+                output.append(f"Way {i}: Tag={hex(line['tag'])}")
+        return "\n".join(output) if output else "Empty Set"
+
+   
+    @property
+    def associativity(self) -> int:
+        """Return the associativity (number of ways) of the set"""
+        return self.num_ways

--- a/src/cache/cache_set.py
+++ b/src/cache/cache_set.py
@@ -1,152 +1,193 @@
-from datalasses import dataclass
-from typing import Optional, Tuple
+"""
+CacheSet: N-way Set Associative Cache with MESI Protocol and PLRU Replacement
+-----------------------------------------------------------------------------
+Author: Reece Wayt
+Last Modified: May 2021
+Description:
+The CacheSet acts as a container for cache lines within a larger cache structure.
+Parent cache class is expected to:
+1. Handle address decomposition (tag, set index, offset)
+2. Manage multiple CacheSet instances
+3. Handle coherence protocol messages
+4. Manage communication with upper/lower cache levels
+
+Basic Operations:
+------------------------------------------------------------------------------
+- read(tag): Check if tag exists in set
+- write(tag): Update existing line in set
+- allocate(tag, state): Insert new line, potentially evicting existing line
+
+MESI Protocol Support:
+------------------------------------------------------------------------------
+- Modified (M): Line is dirty and exclusive
+- Exclusive (E): Line is clean and exclusive
+- Shared (S): Line is clean and may exist in other caches
+- Invalid (I): Line is unused/invalid
+
+Replacement Policy:
+------------------------------------------------------------------------------
+Uses pseudo-LRU (tree-based) for selecting victim lines during allocation.
+For n-way associative set, uses (n-1) bits to maintain binary tree state.
+
+Constraints:
+------------------------------------------------------------------------------
+- num_ways must be power of 2 between MIN_WAYS and MAX_WAYS
+- Each cache line tracks MESI state and L1 inclusion
+- Parent cache must handle writebacks and inclusion policy
+
+Note:
+------------------------------------------------------------------------------
+This implementation focuses on fundamental cache operations. Parent cache
+class is responsible for more complex operations like snoop handling,
+coherence messages, and inclusion enforcement.
+"""
+
 import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
 
-class MESIState(Enum):
-    """
-    Cache coherency states for the MESI protocol (2-bit encoding):
-    
-    M (Modified)  - Line is dirty and exclusive to this cache (0b11)
-    E (Exclusive) - Line is clean and exclusive to this cache (0b10)
-    S (Shared)    - Line is clean and may exist in other caches (0b01)
-    I (Invalid)   - Line is invalid/unused (0b00)
+from common.constants import MESIState
 
-    Source :  
-        - https://en.wikipedia.org/wiki/MESI_protocol
-    """
-    INVALID = 0     # 0b00
-    SHARED = 1      # 0b01
-    EXCLUSIVE = 2   # 0b10
-    MODIFIED = 3    # 0b11
-
-    @property
-    def bits(self) -> int:
-        """Returns the 2-bit encoding of the state"""
-        return self.value
 
 @dataclass
 class CacheLine:
     """
     Represents a cache line with MESI protocol state tracking and L1 inclusion status.
     """
+
     tag: Optional[int] = None
     mesi_state: MESIState = MESIState.INVALID
-    in_l1: bool = False     # For cache coherency
+    in_l1: bool = False  # For cache coherency
 
     def is_invalid(self) -> bool:
         """Check if line is in Invalid state"""
         return self.mesi_state == MESIState.INVALID
-    
+
     def is_shared(self) -> bool:
         """Check if line is in Shared state"""
         return self.mesi_state == MESIState.SHARED
-    
+
     def is_exclusive(self) -> bool:
         """Check if line is in Exclusive state"""
         return self.mesi_state == MESIState.EXCLUSIVE
-    
+
     def is_modified(self) -> bool:
         """Check if line is in Modified state"""
         return self.mesi_state == MESIState.MODIFIED
-    
+
     def set_invalid(self):
         """Set line to Invalid state"""
         self.mesi_state = MESIState.INVALID
-        
+
     def set_shared(self):
         """Set line to Shared state"""
         self.mesi_state = MESIState.SHARED
-        
+
     def set_exclusive(self):
         """Set line to Exclusive state"""
         self.mesi_state = MESIState.EXCLUSIVE
-        
+
     def set_modified(self):
         """Set line to Modified state"""
         self.mesi_state = MESIState.MODIFIED
-    
+
     def get_state_bits(self) -> int:
         """Returns the 2-bit encoding of the current MESI state"""
         return self.mesi_state.bits
 
     def __str__(self) -> str:
         """String representation of the cache line"""
-        return f"Tag={hex(self.tag) if self.tag is not None else 'None'}, " \
-               f"State={self.mesi_state.name}, " \
-               f"In L1={self.in_l1}"
+        return (
+            f"Tag={hex(self.tag) if self.tag is not None else 'None'}, "
+            f"State={self.mesi_state.name}, "
+            f"In L1={self.in_l1}"
+        )
 
 
-class CacheSet:
+class CacheSetPLRUMESI:
     """
     Implements an N-way set associative cache set with MESI protocol and PLRU replacement.
     Default configuration is 16-way, with supported ways from 1 to 32 (must be power of 2).
     """
+
     MAX_WAYS = 32  # Maximum supported ways
-    MIN_WAYS = 1   # Minimum supported ways
+    MIN_WAYS = 1  # Minimum supported ways
 
     def __init__(self, num_ways: int = 16):
         # Validate num_ways
         if not isinstance(num_ways, int):
             raise TypeError("Number of ways must be an integer")
         if num_ways < self.MIN_WAYS or num_ways > self.MAX_WAYS:
-            raise ValueError(f"Number of ways must be between {self.MIN_WAYS} and {self.MAX_WAYS}")
+            raise ValueError(
+                f"Number of ways must be between {self.MIN_WAYS} and {self.MAX_WAYS}"
+            )
         if not (num_ways & (num_ways - 1) == 0):
             raise ValueError("Number of ways must be a power of 2")
-        
+
         self.num_ways = num_ways
         self.tree_levels = int(math.log2(num_ways))  # Levels in PLRU tree
-        
+
         # Initialize cache lines
         self.ways = [CacheLine() for _ in range(num_ways)]
-        
+
         # Initialize PLRU state - only need (num_ways - 1) bits for tree
         self.state = 0
-        
+
     def __get_parent(self, node: int) -> int:
         """Helper method for PLRU tree traversal"""
         return (node - 1) // 2
 
     def __update_plru(self, way_index: int) -> None:
         """
-        Update PLRU state when a way is accessed.
+        Update PLRU state when a way is accessed. If left child is accessed, parent bit is cleared.
+        If right child is accessed, parent bit is set.
         """
         if way_index >= self.num_ways:
-            raise ValueError(f"Way index {way_index} out of range for {self.num_ways}-way set")
-            
-        # PLRU bits are updated with a bottom up tree traversal
-        leaf_node = way_index + (self.num_ways -1)  # Convert way index to a leaf_node number
-        node = self.get_parent(leaf_node)           # Use leaf node to get first internal node (i.e. PLRU bit)
+            raise ValueError(
+                f"Way index {way_index} out of range for {self.num_ways}-way set"
+            )
 
-        if way_index % 2 == 0:                      # Left child accessed
-            self.state &= ~(1 << node)              # Clear node's bit
-        else:                                       # Right child accessed
-            self.state |= (1 << node)               # Set node's bit
-        
+        # PLRU bits are updated with a bottom up tree traversal
+        leaf_node = way_index + (
+            self.num_ways - 1
+        )  # Convert way index to a leaf_node number
+        node = self.__get_parent(
+            leaf_node
+        )  # Use leaf node to get first internal node (i.e. PLRU bit)
+
+        if way_index % 2 == 0:  # Left child accessed
+            self.state &= ~(1 << node)  # Clear node's bit
+        else:  # Right child accessed
+            self.state |= 1 << node  # Set node's bit
+
         while node > 0:
-            parent = self.get_parent(node)
-            if node == 2 * parent + 1:              # Current node is left child
-                self.state &= ~(1 << parent)        # Clear parent's bit
-            else:                                   # Current node is right child
-                self.state |= (1 << parent)         # Set parent's bit
+            parent = self.__get_parent(node)
+            if node == 2 * parent + 1:  # Current node is left child
+                self.state &= ~(1 << parent)  # Clear parent's bit
+            else:  # Current node is right child
+                self.state |= 1 << parent  # Set parent's bit
             node = parent
-    
+
     def __get_plru_victim(self) -> int:
         """
         Find the way to replace according to PLRU policy.
-        Returns: 
-            - Way index [0 - n_ways]
+        Returns:
+            - Way index of victim line
         """
         node = 0
-        for _ in range(self.tree_levels):           
+        for _ in range(self.tree_levels):
             if self.state & (1 << node):
                 node = 2 * node + 1  # Go left
             else:
                 node = 2 * node + 2  # Go right
         # Calculate leaf node index based on number of ways
         return node - (self.num_ways - 1)
-    
+
     def __find_line(self, tag: int) -> Tuple[Optional[CacheLine], Optional[int]]:
-        """Find a cache line by tag. Returns (line, way_index) or (None, None)"""
+        """
+        Private Search Method: Find a cache line by tag.
+            Returns (line, way_index) or (None, None)
+        """
         for i, line in enumerate(self.ways):
             if not line.is_invalid() and line.tag == tag:
                 return line, i
@@ -154,38 +195,45 @@ class CacheSet:
 
     def read(self, tag: int) -> bool:
         """
-        Simulates a read request to a cache set. If tag is found returns valid, else
-        a cacheline fill is requested. Upon a valid access plru bits are updated. 
+        Simulates a read request to a cache set. If tag is found returns HIT, else MISS.
+        Upon a valid access plru bits are updated.
         """
         line, way_index = self.__find_line(tag)
         if line is not None:  # Hit
+            # Update PLRU state bits on hit
             self.__update_plru(way_index)
             return True
-        return False          # Miss
+        return False  # Miss
 
     def write(self, tag: int) -> bool:
         """
-        Simulates a cache write request to a set. Write allocate policy is employed so any 
-        write misses require cache to allocate line. 
+        Simulates a cache write request to a set. Write allocate policy is employed so any
+        write misses require cache to allocate line.
+        If tag is found returns HIT, else MISS.
         """
         line, way_index = self.__find_line(tag)
         if line is not None:  # Hit
             self.__update_plru(way_index)
-            
-            return True
-        return False          # Miss
 
-    def allocate(self, tag: int, state: MESIState = MESIState.EXCLUSIVE) -> int:
+            return True
+        return False  # Miss
+
+    def allocate(
+        self, tag: int, state: MESIState = MESIState.EXCLUSIVE
+    ) -> Tuple[Optional[CacheLine], int]:
         """
-        Allocate a new cache line. First searches for invalid lines,
+        Allocate a new cache line. First searches for invalid lines
         if none found uses PLRU to select victim.
-    
         Args:
             tag: Tag to be stored in the cache line
             state: Initial MESI state (default Exclusive for new allocations)
-        
-        Returns: 
-         way_index where line was allocated
+
+        Returns:
+            (victim_line , allocated_way_index)
+            - victim_line: CacheLine object of the victim line
+            - If victim_line is None, no writeback needed (invalid line was used)
+            - If victim_line is Modified, writeback needed
+            - victim_line contains tag and L1 status for inclusion handling
         """
         # First check for invalid lines
         for way_index, line in enumerate(self.ways):
@@ -193,31 +241,34 @@ class CacheSet:
                 # Found an invalid line, use it
                 line.tag = tag
                 line.mesi_state = state
+                line.in_l1 = False
                 self.__update_plru(way_index)
-                return way_index
-            
+                return None, way_index
         # No invalid lines found, use PLRU to select victim
         victim_way = self.__get_plru_victim()
         victim_line = self.ways[victim_way]
-    
+        # Save victim info before overwriting
+        victim_info = CacheLine(
+            tag=victim_line.tag,
+            mesi_state=victim_line.mesi_state,
+            in_l1=victim_line.in_l1,
+        )
         # Set up new line
         victim_line.tag = tag
         victim_line.mesi_state = state
-        victim_line.in_l1 = False  # Reset L1 inclusion status
-    
+        victim_line.in_l1 = False
+        # Update PLRU based on new line access
         self.__update_plru(victim_way)
-    return victim_way
-
+        return victim_info, victim_way
 
     def __str__(self) -> str:
         """String representation showing valid lines"""
         output = []
         for i, line in enumerate(self.ways):
-            if line['valid']:
+            if line["valid"]:
                 output.append(f"Way {i}: Tag={hex(line['tag'])}")
         return "\n".join(output) if output else "Empty Set"
 
-   
     @property
     def associativity(self) -> int:
         """Return the associativity (number of ways) of the set"""

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -58,4 +58,28 @@ class TraceCommand(IntEnum):
     SNOOP_RWIM = 5  # snooped read with intent to modify
     SNOOP_INVALIDATE = 6  # snooped invalidate command
     CLEAR_CACHE = 8  # clear cache and reset all state
-    PRINT_CACHE = 9  # print contents and state of valid linesa
+    PRINT_CACHE = 9  # print contents and state of valid lines
+
+
+class MESIState(IntEnum):
+    """
+    Cache coherency states for the MESI protocol (2-bit encoding):
+
+    M (Modified)  - Line is dirty and exclusive to this cache (0b11)
+    E (Exclusive) - Line is clean and exclusive to this cache (0b10)
+    S (Shared)    - Line is clean and may exist in other caches (0b01)
+    I (Invalid)   - Line is invalid/unused (0b00)
+
+    Source :
+        - https://en.wikipedia.org/wiki/MESI_protocol
+    """
+
+    INVALID = 0  # 0b00
+    SHARED = 1  # 0b01
+    EXCLUSIVE = 2  # 0b10
+    MODIFIED = 3  # 0b11
+
+    @property
+    def bits(self) -> int:
+        """Returns the 2-bit encoding of the state"""
+        return self.value

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ Description: This program simulates the behavior of a 16MB, 16-way set associati
 """
 
 import sys
+
 from common.constants import LogLevel
 from config.project_config import config
 from utils.event_handler import handle_event

--- a/tests/cache/TEST_PLAN_CACHE_SET.md
+++ b/tests/cache/TEST_PLAN_CACHE_SET.md
@@ -1,0 +1,274 @@
+# Test Plan for CacheSet
+
+## Overview
+- This test plan covers the verification of the CacheSet class. The main responsibilities of the CacheSet is to store and maintain n-ways of CacheLine Data Classes. Replacement or eviction of a CacheLine is determine by the PLRU algorightm. The CacheSet also implements MESI protocol state tracking for cache coherency.  
+
+**Note: that MESI protocol and state transistion are not part of this test set. Also, a default 16-way set is tested, although CacheSet support n-ways** 
+
+## Running Tests
+```bash
+python -m unittest tests.cache.tests_cache_set -v
+```
+
+## Test Cases and Results
+
+### 1. Constructor Validation Tests (test_constructor_validation)
+* Purpose: Verify constructor properly validates num_ways parameter
+* Test cases:
+  - Valid ways: [1, 2, 4, 8, 16, 32]
+  - Invalid types: float (2.5), string ("16")
+  - Invalid ranges: 0, 33, -1
+  - Non-power-of-2: 3
+* Status: ✅ PASS
+
+### 2. Initial State Tests (test_initial_state)
+* Purpose: Verify initial state of newly created cache set
+* Test cases:
+  - Verify 16 ways created
+  - Verify PLRU state = 0
+  - Verify all lines invalid
+  - Verify all tags None
+* Status: ✅ PASS
+
+### 3. PLRU Behavior Tests
+#### 3.1 Basic PLRU Updates (test_plru_update)
+* Purpose: Verify basic PLRU bit pattern updates
+* Test sequence:
+  - Access way 0: 0b000_0000_0000_0000
+  - Access way 1: 0b000_0000_1000_0000
+  - Access way 8: 0b000_0000_1000_0001
+  - Access way 15: 0b100_0000_1100_0101
+* Status: ✅ PASS
+
+#### 3.2 Complex PLRU Pattern (test_plru_behavior)
+* Purpose: Verify PLRU behavior for complex access patterns
+* Test cases:
+  1. Sequential Access to All Ways (0-15)
+  2. Follow-up accesses to ways 8 and 2
+  3. Verify final state: 0b111_0110_1101_1000
+* Status: ✅ PASS
+
+### 4. Cache Operations Tests
+#### 4.1 Read Operations (test_read_operations)
+* Purpose: Verify read hits/misses
+* Test cases:
+  - Read miss on empty cache
+  - Read hit after allocation
+  - Read miss on different tag
+* Status: ✅ PASS
+
+#### 4.2 Write Operations (test_write_operations)
+* Purpose: Verify write hits/misses
+* Test cases:
+  - Write miss on empty cache
+  - Write hit after allocation
+  - Write miss on different tag
+* Status: ✅ PASS
+
+#### 4.3 Allocation Sequence (test_plru_allocation_sequence)
+* Purpose: Verify realistic allocation sequence
+* Test sequence:
+  1. Sequential allocation (ways 0-15)
+  2. Access ways 8 and 2
+  3. Final allocation verifying:
+     - Correct victim selection (way 12)
+     - Proper victim tag (0xC)
+     - Expected PLRU state
+* Status: ✅ PASS
+
+## Test Coverage Summary
+- Total Tests: 7
+- Passed: 7
+- Failed: 0
+- Test Duration: 0.001s
+
+## Key Verifications
+1. ✅ Constructor parameter validation
+2. ✅ Initial state correctness
+3. ✅ PLRU bit pattern accuracy
+4. ✅ Cache operation functionality
+5. ✅ Replacement policy correctness
+6. ✅ Error handling
+
+## Notes
+- All PLRU state transitions are verified using binary pattern matching
+- Test output includes detailed state information for debugging see below
+```bash
+╭─  Linux 17:30 ~/S/P/ECE585-llc/src 
+│ on  feature/cache-set [!+] 🐍 v3.12.7 
+╰─❯ python -m unittest tests.cache.tests_cache_set -v
+test_constructor_validation (tests.cache.tests_cache_set.TestCacheSet.test_constructor_validation)
+Test constructor parameter validation ... ok
+test_initial_state (tests.cache.tests_cache_set.TestCacheSet.test_initial_state)
+Test initial state of newly created cache set ... ok
+test_plru_allocation_sequence (tests.cache.tests_cache_set.TestCacheSet.test_plru_allocation_sequence)
+Test PLRU behavior during a realistic allocation sequence. ... 
+Allocation 0 - Tag 0x0:
+Selected way: 0
+PLRU state:   000000000000000
+
+Allocation 1 - Tag 0x1:
+Selected way: 1
+PLRU state:   000000010000000
+
+Allocation 2 - Tag 0x2:
+Selected way: 2
+PLRU state:   000000010001000
+
+Allocation 3 - Tag 0x3:
+Selected way: 3
+PLRU state:   000000110001000
+
+Allocation 4 - Tag 0x4:
+Selected way: 4
+PLRU state:   000000110001010
+
+Allocation 5 - Tag 0x5:
+Selected way: 5
+PLRU state:   000001110001010
+
+Allocation 6 - Tag 0x6:
+Selected way: 6
+PLRU state:   000001110011010
+
+Allocation 7 - Tag 0x7:
+Selected way: 7
+PLRU state:   000011110011010
+
+Allocation 8 - Tag 0x8:
+Selected way: 8
+PLRU state:   000011110011011
+
+Allocation 9 - Tag 0x9:
+Selected way: 9
+PLRU state:   000111110011011
+
+Allocation 10 - Tag 0xa:
+Selected way: 10
+PLRU state:   000111110111011
+
+Allocation 11 - Tag 0xb:
+Selected way: 11
+PLRU state:   001111110111011
+
+Allocation 12 - Tag 0xc:
+Selected way: 12
+PLRU state:   001111110111111
+
+Allocation 13 - Tag 0xd:
+Selected way: 13
+PLRU state:   011111110111111
+
+Allocation 14 - Tag 0xe:
+Selected way: 14
+PLRU state:   011111111111111
+
+Allocation 15 - Tag 0xf:
+Selected way: 15
+PLRU state:   111111111111111
+
+Final allocation - Tag 0xAAAA:
+Selected way: 12
+PLRU state:   101011010011101
+Victim tag:   0xc
+ok
+test_plru_behavior (tests.cache.tests_cache_set.TestCacheSet.test_plru_behavior)
+Test of PLRU behavior using predefined test cases that ... 
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 0 access:
+Current state:  000000000000000
+Expected state: 000000000000000
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 1 access:
+Current state:  000000010000000
+Expected state: 000000010000000
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 2 access:
+Current state:  000000010001000
+Expected state: 000000010001000
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 3 access:
+Current state:  000000110001000
+Expected state: 000000110001000
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 4 access:
+Current state:  000000110001010
+Expected state: 000000110001010
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 5 access:
+Current state:  000001110001010
+Expected state: 000001110001010
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 6 access:
+Current state:  000001110011010
+Expected state: 000001110011010
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 7 access:
+Current state:  000011110011010
+Expected state: 000011110011010
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 8 access:
+Current state:  000011110011011
+Expected state: 000011110011011
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 9 access:
+Current state:  000111110011011
+Expected state: 000111110011011
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 10 access:
+Current state:  000111110111011
+Expected state: 000111110111011
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 11 access:
+Current state:  001111110111011
+Expected state: 001111110111011
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 12 access:
+Current state:  001111110111111
+Expected state: 001111110111111
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 13 access:
+Current state:  011111110111111
+Expected state: 011111110111111
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 14 access:
+Current state:  011111111111111
+Expected state: 011111111111111
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 15 access:
+Current state:  111111111111111
+Expected state: 111111111111111
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 8 access:
+Current state:  111011111011011
+Expected state: 111011111011011
+
+Sequential Access to All 16 Ways, then access 8, and 2 repectively - After way 2 access:
+Current state:  111011011011000
+Expected state: 111011011011000
+ok
+test_plru_update (tests.cache.tests_cache_set.TestCacheSet.test_plru_update)
+Test PLRU bit updates after access (basic test) ... After way 0 access:
+Current state:  000000000000000
+Expected state: 000000000000000
+After way 1 access:
+Current state:  000000010000000
+Expected state: 000000010000000
+After way 8 access:
+Current state:  000000010000001
+Expected state: 000000010000001
+After way 15 access: 
+Current state:  100000011000101
+Expected state: 100000011000101
+ok
+test_read_operations (tests.cache.tests_cache_set.TestCacheSet.test_read_operations)
+Test cache read operations ... ok
+test_write_operations (tests.cache.tests_cache_set.TestCacheSet.test_write_operations)
+Test cache write operations ... ok
+
+----------------------------------------------------------------------
+Ran 7 tests in 0.001s
+
+OK
+
+
+```

--- a/tests/cache/test_cache_set.py
+++ b/tests/cache/test_cache_set.py
@@ -40,7 +40,7 @@ class TestCacheSet(unittest.TestCase):
 
         # Check all ways are properly initialized
         for way in self.cache_set.ways:
-            self.assertIsNone(way.tag)
+            self.assertEqual(way.tag, 0)
             self.assertTrue(way.is_invalid())
 
     def test_read_operations(self):

--- a/tests/cache/tests_cache_set.py
+++ b/tests/cache/tests_cache_set.py
@@ -1,0 +1,247 @@
+import unittest
+
+from cache.cache_set import CacheSetPLRUMESI
+
+
+class TestCacheSet(unittest.TestCase):
+    """Unit tests for CacheSet implementation"""
+
+    def setUp(self):
+        """Create a default 16-way cache set for testing"""
+        self.cache_set = CacheSetPLRUMESI(num_ways=16)
+
+    def test_constructor_validation(self):
+        """Test constructor parameter validation"""
+        # Valid cases
+        valid_ways = [1, 2, 4, 8, 16, 32]
+        for ways in valid_ways:
+            with self.subTest(ways=ways):
+                cache_set = CacheSetPLRUMESI(num_ways=ways)
+                self.assertEqual(cache_set.associativity, ways)
+
+        # Invalid cases
+        with self.assertRaises(TypeError):
+            CacheSetPLRUMESI(num_ways=2.5)
+        with self.assertRaises(TypeError):
+            CacheSetPLRUMESI(num_ways="16")
+        with self.assertRaises(ValueError):
+            CacheSetPLRUMESI(num_ways=0)
+        with self.assertRaises(ValueError):
+            CacheSetPLRUMESI(num_ways=33)
+        with self.assertRaises(ValueError):
+            CacheSetPLRUMESI(num_ways=-1)
+        with self.assertRaises(ValueError):
+            CacheSetPLRUMESI(num_ways=3)  # Not power of 2
+
+    def test_initial_state(self):
+        """Test initial state of newly created cache set"""
+        self.assertEqual(len(self.cache_set.ways), 16)
+        self.assertEqual(self.cache_set.state, 0)  # Initial PLRU state
+
+        # Check all ways are properly initialized
+        for way in self.cache_set.ways:
+            self.assertIsNone(way.tag)
+            self.assertTrue(way.is_invalid())
+
+    def test_read_operations(self):
+        """Test cache read operations"""
+        # Read miss on empty cache
+        self.assertFalse(self.cache_set.read(0x1234))
+
+        # Allocate line and verify read hit
+        self.cache_set.allocate(0x1234)
+        self.assertTrue(self.cache_set.read(0x1234))
+
+        # Read miss on different tag
+        self.assertFalse(self.cache_set.read(0x5678))
+
+    def test_write_operations(self):
+        """Test cache write operations"""
+        # Write miss on empty cache
+        self.assertFalse(self.cache_set.write(0x1234))
+
+        # Allocate line and verify write hit
+        self.cache_set.allocate(0x1234)
+        self.assertTrue(self.cache_set.write(0x1234))
+
+        # Write miss on different tag
+        self.assertFalse(self.cache_set.write(0x5678))
+
+    def test_plru_update(self):
+        """Test PLRU bit updates after access (basic test)
+        When accessing a way:
+            - Left child access: set parent bit to 0
+            - Right child access: set parent bit to 1
+        """
+        # Access first way
+        self.cache_set._CacheSetPLRUMESI__update_plru(0)
+        expected_state = 0b000_0000_0000_0000
+        print("After way 0 access:")
+        print(f"Current state:  {self.cache_set.state:015b}")
+        print(f"Expected state: {expected_state:015b}")
+        self.assertEqual(self.cache_set.state, expected_state)
+
+        # Access second way
+        self.cache_set._CacheSetPLRUMESI__update_plru(1)
+        expected_state = 0b000_0000_1000_0000
+        print("After way 1 access:")
+        print(f"Current state:  {self.cache_set.state:015b}")
+        print(f"Expected state: {expected_state:015b}")
+        self.assertEqual(self.cache_set.state, expected_state)
+
+        # Test way 8 access
+        self.cache_set._CacheSetPLRUMESI__update_plru(8)
+        expected_state = 0b000_0000_1000_0001
+        print("After way 8 access:")
+        print(f"Current state:  {self.cache_set.state:015b}")
+        print(f"Expected state: {expected_state:015b}")
+        self.assertEqual(self.cache_set.state, expected_state)
+
+        # Test way 15 access
+        self.cache_set._CacheSetPLRUMESI__update_plru(15)
+        expected_state = 0b100_0000_1100_0101
+        print("After way 15 access: ")
+        print(f"Current state:  {self.cache_set.state:015b}")
+        print(f"Expected state: {expected_state:015b}")
+        self.assertEqual(self.cache_set.state, expected_state)
+
+    def test_plru_behavior(self):
+        """
+        Test of PLRU behavior using predefined test cases that
+        model real cache access patterns. Each test case verifies both the
+        PLRU state updates and victim selection.
+        """
+        test_cases = [
+            {
+                "name": "Sequential Access to All 16 Ways, then access 8, and 2 repectively",
+                "access_pattern": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    8,
+                    2,
+                ],
+                "states": [
+                    (0, 0b000_0000_0000_0000),  # After way 0
+                    (1, 0b000_0000_1000_0000),  # After way 1
+                    (2, 0b000_0000_1000_1000),  # After way 2
+                    (3, 0b000_0001_1000_1000),  # After way 3
+                    (4, 0b000_0001_1000_1010),  # After way 4
+                    (5, 0b000_0011_1000_1010),  # After way 5
+                    (6, 0b000_0011_1001_1010),  # After way 6
+                    (7, 0b000_0111_1001_1010),  # After way 7
+                    (8, 0b000_0111_1001_1011),  # After way 8
+                    (9, 0b000_1111_1001_1011),  # After way 9
+                    (10, 0b000_1111_1011_1011),  # After way 10
+                    (11, 0b001_1111_1011_1011),  # After way 11
+                    (12, 0b001_1111_1011_1111),  # After way 12
+                    (13, 0b011_1111_1011_1111),  # After way 13
+                    (14, 0b011_1111_1111_1111),  # After way 14
+                    (15, 0b111_1111_1111_1111),  # After way 15
+                    (8, 0b111_0111_1101_1011),  # After way 8
+                    (2, 0b111_0110_1101_1000),  # After way 2
+                ],
+                "expected_victim": 12,
+            },
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(name=test_case["name"]):
+                # Reset cache state for each test case
+                self.setUp()
+
+                # Execute access pattern and verify states
+                for i, way in enumerate(test_case["access_pattern"]):
+                    self.cache_set._CacheSetPLRUMESI__update_plru(way)
+                    expected_way, expected_state = test_case["states"][i]
+
+                    # Debug output
+                    print(f"\n{test_case['name']} - After way {way} access:")
+                    print(f"Current state:  {self.cache_set.state:015b}")
+                    print(f"Expected state: {expected_state:015b}")
+
+                    self.assertEqual(
+                        self.cache_set.state,
+                        expected_state,
+                        f"PLRU state mismatch after accessing way {way}",
+                    )
+
+                # Verify final victim selection
+                victim = self.cache_set._CacheSetPLRUMESI__get_plru_victim()
+                self.assertEqual(
+                    victim,
+                    test_case["expected_victim"],
+                    f"Wrong victim selected. Expected {test_case['expected_victim']}, got {victim}",
+                )
+
+    def test_plru_allocation_sequence(self):
+        """
+        Test PLRU behavior during a realistic allocation sequence.
+        First fill all ways sequentially, then access ways 8 and 2,
+        and finally allocate a new line which should evict way 12.
+        """
+        # Fill all ways sequentially
+        allocation_sequence = [
+            {"tag": 0x0, "expected_way": 0, "expected_victim": None},
+            {"tag": 0x1, "expected_way": 1, "expected_victim": None},
+            {"tag": 0x2, "expected_way": 2, "expected_victim": None},
+            {"tag": 0x3, "expected_way": 3, "expected_victim": None},
+            {"tag": 0x4, "expected_way": 4, "expected_victim": None},
+            {"tag": 0x5, "expected_way": 5, "expected_victim": None},
+            {"tag": 0x6, "expected_way": 6, "expected_victim": None},
+            {"tag": 0x7, "expected_way": 7, "expected_victim": None},
+            {"tag": 0x8, "expected_way": 8, "expected_victim": None},
+            {"tag": 0x9, "expected_way": 9, "expected_victim": None},
+            {"tag": 0xA, "expected_way": 10, "expected_victim": None},
+            {"tag": 0xB, "expected_way": 11, "expected_victim": None},
+            {"tag": 0xC, "expected_way": 12, "expected_victim": None},
+            {"tag": 0xD, "expected_way": 13, "expected_victim": None},
+            {"tag": 0xE, "expected_way": 14, "expected_victim": None},
+            {"tag": 0xF, "expected_way": 15, "expected_victim": None},
+        ]
+
+        # Perform initial allocations
+        for i, alloc in enumerate(allocation_sequence):
+            with self.subTest(step=f"Initial allocation {i}"):
+                victim_line, way = self.cache_set.allocate(alloc["tag"])
+                print(f"\nAllocation {i} - Tag {hex(alloc['tag'])}:")
+                print(f"Selected way: {way}")
+                print(f"PLRU state:   {self.cache_set.state:015b}")
+
+                self.assertEqual(way, alloc["expected_way"])
+                self.assertIsNone(victim_line)  # No victims during initial fill
+
+        # Access way 8 and 2 to match the PLRU pattern
+        self.assertTrue(self.cache_set.read(0x8))  # Access way 8
+        self.assertTrue(self.cache_set.read(0x2))  # Access way 2
+
+        # Now allocate a new line - should evict way 12
+        victim_line, way = self.cache_set.allocate(0xAAAA)
+        print("\nFinal allocation - Tag 0xAAAA:")
+        print(f"Selected way: {way}")
+        print(
+            f"PLRU state:   {self.cache_set.state:015b}"
+        )  # Expected: 0b101_0110_1001_1101
+        print(f"Victim tag:   {hex(victim_line.tag) if victim_line else None}")
+
+        # Verify the final allocation
+        self.assertEqual(way, 12)  # Should use way 12
+        self.assertIsNotNone(victim_line)  # Should have a victim
+        self.assertEqual(victim_line.tag, 0xC)  # Victim should have tag 0xC
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR implements our n-way cache sets with support for PLRU (Pseudo Least Recently Used) replacement. The implementation uses a CacheLine data class to manage tag arrays and MESI states. Each set maintains a list of `n` CacheLines.  The cache set is designed to be instantiated by a parent class.

A detailed description of the CacheSet class functionality can be found in the source code documentation. The PR includes  unit tests with emphasis on validating the PLRU algorithm's bit patterns and victim selection behavior. All test cases are passing and verify proper operation of:
- PLRU state transitions
- Cache line allocation/eviction
- Basic cache operations (read/write)
- Constructor validation