### PR TITLE
Add initial integration tests for events 0 and 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==24.10.0
+callee==0.3.1
 cfgv==3.4.0
 click==8.1.7
 distlib==0.3.9

--- a/tests/integration/integration_setup.py
+++ b/tests/integration/integration_setup.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from cache.cache import Cache
+from config.cache_config import CacheConfig
+from cache.bus_interface import BusInterface
+from cache.l1_interface import L1Interface
+
+
+class IntegrationSetup(unittest.TestCase):
+    """
+    Base setup for our integration tests.
+    The tests and test fixtures assume our default cache configuration:
+    - 32-bit addresses
+    - 16 MiB cache capacity
+    - 64 byte cache lines
+    - MESI protocol
+    - 16-way set associativity
+
+    Extension of our integration test suite to support other configurations
+    should entail creating different fixtures. Some of the individual tests
+    may share logic (for example, in the event sequence), but will likely
+    need modification to handle the specifics of other coherence protocols.
+    """
+
+    # Define class attributes with possible addresses for each snoop result
+    # These will serve as fixtures for tests in child classes
+    hit_addresses = [0x10000000, 0x20000004, 0x30000008, 0x4000000C]  # LSBs 00
+    hitm_addresses = [0x10000001, 0x20000005, 0x30000009, 0x4000000D]  # LSBs 01
+    nohit_addresses = [0x10000002, 0x20000006, 0x3000000A, 0x4000000F]  # LSBs 10 or 11
+
+    # Setup resources for all tests in the class
+    @classmethod
+    def setUpClass(cls):
+        # Initialize cache configuration and mocks
+        cls.cache_config = CacheConfig()
+        cls.mock_logger = MagicMock()
+        cls.mock_args = MagicMock(silent=False, debug=True)
+
+        # Patch the config logger and args
+        patch(
+            "config.project_config.config.get_logger", return_value=cls.mock_logger
+        ).start()
+        patch(
+            "config.project_config.config.get_args", return_value=cls.mock_args
+        ).start()
+
+        BusInterface.initialize(cls.mock_logger)
+        L1Interface.initialize(cls.mock_logger)
+
+    # Cleanup after all tests in the class
+    @classmethod
+    def tearDownClass(cls):
+        patch.stopall()
+
+    def setUp(self):
+        # Set up a new cache instance for each test using the
+        # mocked logger that's shared across all tests
+        self.cache = Cache(self.cache_config, self.mock_logger)
+
+    # Placeholder for any teardown that needs to happen
+    # after *each* test is run
+    def tearDown(self):
+        pass
+
+    # Helper function to check MESI state
+    def check_line_state(self, addr, expected_state):
+        line = self.cache.lookup_line(addr)
+        self.assertIsNotNone(line, f"Line at address {hex(addr)} not found in cache.")
+        self.assertEqual(
+            line.mesi_state,
+            expected_state,
+            f"Unexpected MESI state at address {hex(addr)}.",
+        )

--- a/tests/integration/integration_setup.py
+++ b/tests/integration/integration_setup.py
@@ -47,6 +47,10 @@ class IntegrationSetup(unittest.TestCase):
             "config.project_config.config.get_args", return_value=cls.mock_args
         ).start()
 
+        # Need to ensure we're using new singleton instances
+        # that have the current mock_logger
+        BusInterface._bus_instance = None
+        L1Interface._l1_instance = None
         BusInterface.initialize(cls.mock_logger)
         L1Interface.initialize(cls.mock_logger)
 
@@ -62,7 +66,7 @@ class IntegrationSetup(unittest.TestCase):
 
     # Teardown that needs to happen after *each* test is run
     def tearDown(self):
-        pass
+        self.mock_logger.reset_mock()
 
     # Helper function to check MESI state
     def check_line_state(self, addr, expected_state):

--- a/tests/integration/test_l1_read_request.py
+++ b/tests/integration/test_l1_read_request.py
@@ -1,0 +1,189 @@
+import unittest
+from common.constants import MESIState
+from utils.event_handler import handle_event
+from tests.integration.integration_setup import IntegrationSetup
+
+
+class TestCommandL1ReadRequestData(IntegrationSetup):
+
+    def setUp(self):
+        super().setUp()
+        # nohit_addr is an address that results in a simulated
+        # NOHIT snoop response from other caches
+        self.nohit_addr = self.nohit_addresses[0]
+        # hit_addr is an address that results in a simulated
+        # HIT snoop response from other caches
+        self.hit_addr = self.hit_addresses[0]
+        # hitm_addr is an address that results in a simulated
+        # HITM snoop response from other caches
+        self.hitm_addr = self.hitm_addresses[0]
+
+    def test_exclusive(self):
+        """
+        Test reading a line in the Exclusive state.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss)
+        - Read line (cache hit)
+        """
+        # Increment expected stats values based on actions we
+        # expect to modify the cache statistics object
+        # Note: these values are not determined by the actual
+        # return value of the functions being called
+        expected_reads = 0
+        expected_writes = 0
+        expected_hits = 0
+        expected_misses = 0
+
+        # Event 0: Read miss at self.nohit_addr (gets line in E state)
+        handle_event(self.cache, 0, self.nohit_addr)
+        expected_misses += 1
+        expected_reads += 1
+        self.check_line_state(self.nohit_addr, MESIState.EXCLUSIVE)
+
+        # Event 0: Read hit at self.nohit_addr (should stay in E state)
+        handle_event(self.cache, 0, self.nohit_addr)
+        expected_hits += 1
+        expected_reads += 1
+        self.check_line_state(self.nohit_addr, MESIState.EXCLUSIVE)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, expected_reads)
+        self.assertEqual(self.cache.statistics.cache_writes, expected_writes)
+        self.assertEqual(self.cache.statistics.cache_hits, expected_hits)
+        self.assertEqual(self.cache.statistics.cache_misses, expected_misses)
+
+    def test_modified(self):
+        """
+        Test reading a line in the Modified state.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss)
+        - Write line (cache hit)
+        - Read line (cache hit)
+        """
+        # Event 0: Read miss at self.nohit_addr (gets line in E state)
+        handle_event(self.cache, 0, self.nohit_addr)
+        self.check_line_state(self.nohit_addr, MESIState.EXCLUSIVE)
+
+        # Event 1: Write hit at self.nohit_addr (line moves to M state)
+        handle_event(self.cache, 1, self.nohit_addr)
+        self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
+
+        # Event 0: Read hit at self.nohit_addr (should stay in M state)
+        handle_event(self.cache, 0, self.nohit_addr)
+        self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
+
+        # Assertions for statistics
+        # As an alternative to the above that accumulates the expected
+        # stats values, we can hardcode them here, which may be more
+        # readable.
+        self.assertEqual(self.cache.statistics.cache_reads, 2)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 2)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_shared(self):
+        """
+        Test reading a line in the Shared state.
+        Other caches return a HIT snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss)
+        - Read line (cache hit)
+        """
+        # Event 0: Read miss at self.hit_addr (gets line in S state)
+        handle_event(self.cache, 0, self.hit_addr)
+        self.check_line_state(self.hit_addr, MESIState.SHARED)
+
+        # Event 0: Read hit at self.hit_addr (should stay in S state)
+        handle_event(self.cache, 0, self.hit_addr)
+        self.check_line_state(self.hit_addr, MESIState.SHARED)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 2)
+        self.assertEqual(self.cache.statistics.cache_writes, 0)
+        self.assertEqual(self.cache.statistics.cache_hits, 1)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_hitm(self):
+        """
+        Test reading a line that's been modified in another cache.
+        Other caches return a HITM snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss, snarf from other cache flushWB)
+        """
+        # Event 0: Read miss at self.hitm_addr (gets line in S state)
+        # Assumes cache with the modified line flushes the line
+        # (with write-back) and our cache snarfs it
+        handle_event(self.cache, 0, self.hitm_addr)
+        self.check_line_state(self.hitm_addr, MESIState.SHARED)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 1)
+        self.assertEqual(self.cache.statistics.cache_writes, 0)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_clean_eviction(self):
+        """
+        Test reading a line that causes an eviction of a clean line.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Read lines to fill the cache (cache misses)
+        - Read line to cause an eviction (cache miss)
+        """
+        # Base addr that returns a NOHIT snoop response from other caches
+        address = 0x00000002  # Start with set 0, offset with NOHIT response
+        increment = 0x100000  # 1 MiB increment to change the tag
+
+        # Fill the cache
+        for _i in range(16):
+            address += increment
+            handle_event(self.cache, 0, address)
+            self.check_line_state(address, MESIState.EXCLUSIVE)
+
+        # One more read to trigger an eviction of a clean line
+        handle_event(self.cache, 0, address + increment)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 17)
+        self.assertEqual(self.cache.statistics.cache_writes, 0)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 17)
+
+    def test_dirty_eviction(self):
+        """
+        Test reading a line that causes an eviction of a dirty line.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Write lines to fill the cache (cache misses)
+        - Read line to cause an eviction (cache miss)
+        """
+        # Base addr that returns a NOHIT snoop response from other caches
+        address = 0x00000002  # Start with set 0, offset with NOHIT response
+        increment = 0x100000  # 1 MiB increment to change the tag
+
+        # Fill the cache
+        for _i in range(16):
+            address += increment
+            handle_event(self.cache, 1, address)
+            self.check_line_state(address, MESIState.MODIFIED)
+
+        # One more read to trigger an eviction of a dirty line
+        handle_event(self.cache, 0, address + increment)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 1)
+        self.assertEqual(self.cache.statistics.cache_writes, 16)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 17)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Begins translating our case analysis to integration tests, which focus on the integration between the individual components.

* Adds a class for integration test setup that should be common most of the integration tests.
* Adds a class for events 0 and 2, which share the same functionality
* Includes assertions to check individual line states, bus operations called on the logger, and resulting cache statistics
* **NOTE**: Some functionality in the source code should be checked or fixed, at which point tests may be updated, and some commented-out tests may be enabled

The following command will run 12 tests - 6 for the data read (event 0) and 6 for the instruction read (event 2):
```sh
PYTHONPATH=./src python -m unittest tests.integration.test_l1_read_request
```

Running just one set of tests (for example, event 2 instruction read) can be done as follows:
```sh
PYTHONPATH=./src python -m unittest tests.integration.test_l1_read_request.TestCommandL1ReadRequestInstruction
```