### PR TITLE
Test trace sequences

### DIFF
--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -111,11 +111,15 @@ class Cache:
 
     def pr_read(self, address: int) -> bool:
         """Processor side read request"""
-        return self.__processor_access(address, is_write=False)
+        hit = self.__processor_access(address, is_write=False)
+        message_to_l1_cache(CacheMessage.SENDLINE, address)
+        return hit
 
     def pr_write(self, address: int) -> bool:
         """Processor side write request"""
-        return self.__processor_access(address, is_write=True)
+        hit = self.__processor_access(address, is_write=True)
+        message_to_l1_cache(CacheMessage.SENDLINE, address)
+        return hit
 
     def __processor_access(self, address: int, is_write: bool) -> bool:
         """

--- a/tests/cache/test_mesi_controller.py
+++ b/tests/cache/test_mesi_controller.py
@@ -85,9 +85,6 @@ class TestMESIProtocol(unittest.TestCase):
         # Check that the snoop result was checked
         self.mock_get_snoop.assert_called_with(0x1000)
 
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
-
         # Assert state transition: INVALID -> EXCLUSIVE
         self.assertEqual(next_state, MESIState.EXCLUSIVE)
 
@@ -108,9 +105,6 @@ class TestMESIProtocol(unittest.TestCase):
 
         # Check that the snoop result was checked
         self.mock_get_snoop.assert_called_with(0x1000)
-
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
 
         # Assert state transition: INVALID -> SHARED
         self.assertEqual(next_state, MESIState.SHARED)
@@ -133,9 +127,6 @@ class TestMESIProtocol(unittest.TestCase):
         # Check that the snoop result was checked
         self.mock_get_snoop.assert_called_with(0x1000)
 
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
-
         # Assert state transition: INVALID -> SHARED
         self.assertEqual(next_state, MESIState.SHARED)
 
@@ -144,7 +135,7 @@ class TestMESIProtocol(unittest.TestCase):
         Test handling a processor write request for a cacheline in INVALID state
         NOTE: Snoop results do not effect the transistion from INVALID to MODIFIED
         on a write, we assume that other caches perform the correct operations
-        when they see a RWIM Bus Operation.  
+        when they see a RWIM Bus Operation.
         """
         address = 0x1000
 
@@ -159,12 +150,8 @@ class TestMESIProtocol(unittest.TestCase):
         # Check that the snoop result was not checked
         self.mock_get_snoop.assert_not_called()
 
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
-
         # Assert state transition: INVALID -> MODIFIED
         self.assertEqual(next_state, MESIState.MODIFIED)
-
 
     def test_processor_read_shared(self):
         """
@@ -183,9 +170,6 @@ class TestMESIProtocol(unittest.TestCase):
 
         # Check that the snoop result was checked
         self.mock_get_snoop.assert_not_called()
-
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
 
         # Assert state transition: SHARED -> SHARED
         self.assertEqual(next_state, MESIState.SHARED)
@@ -227,9 +211,6 @@ class TestMESIProtocol(unittest.TestCase):
         # Check that the snoop result was not checked
         self.mock_get_snoop.assert_not_called()
 
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
-
         # Assert state transition: EXCLUSIVE -> EXCLUSIVE
         self.assertEqual(next_state, MESIState.EXCLUSIVE)
 
@@ -249,11 +230,6 @@ class TestMESIProtocol(unittest.TestCase):
 
         # Check that the snoop result was not checked
         self.mock_get_snoop.assert_not_called()
-
-        # Check that sent line was not called
-        # L1 is write through on first write, so L1 and L2 will have modified line at the
-        # same time
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
 
         # Assert state transition: EXCLUSIVE -> MODIFIED
         self.assertEqual(next_state, MESIState.MODIFIED)
@@ -275,10 +251,6 @@ class TestMESIProtocol(unittest.TestCase):
         # Check that the snoop result was not checked
         self.mock_get_snoop.assert_not_called()
 
-        # Check that the L1 cache was sent send line message as write request to L2 cache
-        # means miss in L1 cache and L2 cache has the data
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
-
         # Assert state transition: MODIFIED -> MODIFIED
         self.assertEqual(next_state, MESIState.MODIFIED)
 
@@ -298,9 +270,6 @@ class TestMESIProtocol(unittest.TestCase):
 
         # Check that the snoop result was not checked
         self.mock_get_snoop.assert_not_called()
-
-        # Check that the L1 cache was sent send line message
-        self.mock_l1_message.assert_called_with(CacheMessage.SENDLINE, address)
 
         # Assert state transition: MODIFIED -> MODIFIED
         self.assertEqual(next_state, MESIState.MODIFIED)

--- a/tests/integration/test_l1_read_request.py
+++ b/tests/integration/test_l1_read_request.py
@@ -44,10 +44,9 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
 
         # Event 0: Read miss at self.nohit_addr (gets line in E state)
         handle_event(self.cache, self.trace_event, self.nohit_addr)
-        # FIXME: Enable this one we've updated the code to send this message
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+
+        # Confirm the L2 sendline message was issued
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
 
         # Check that a bus operation was issued, once per read event
         # with either the name (read) or the operation ID number
@@ -99,12 +98,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.nohit_addr)
         self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
 
-        # FIXME: Enable this one we've updated the code to send this message
-        # We may want to check for multiple calls to sendline here instead
-        # of just the one
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 3)
 
         # Only the first read request should have resulted in a READ
         # bus operation.
@@ -136,12 +131,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.hit_addr)
         self.check_line_state(self.hit_addr, MESIState.SHARED)
 
-        # FIXME: Enable this one we've updated the code to send this message
-        # We may want to check for multiple calls to sendline here instead
-        # of just the one
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
 
         # Only the first read request should have resulted in a READ
         # bus operation.
@@ -167,10 +158,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.hitm_addr)
         self.check_line_state(self.hitm_addr, MESIState.SHARED)
 
-        # FIXME: Enable this one we've updated the code to send this message
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+        # Confirm the L2 sendline message was issued
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
 
         # Check for a single READ bus operation
         self.assert_log_called_once_with(LogLevel.NORMAL, r".*busop.*(read|1).*")
@@ -203,11 +192,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         # One more read to trigger an eviction of a clean line
         handle_event(self.cache, self.trace_event, address + increment)
 
-        # FIXME: Enable this one we've updated the code to send this message
-        # Check for however many sendline events we need (likely 17)
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
 
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(LogLevel.NORMAL, r".*busop.*(read|1).*", 17)
@@ -240,11 +226,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         # One more read to trigger an eviction of a dirty line
         handle_event(self.cache, self.trace_event, address + increment)
 
-        # FIXME: Enable this one we've updated the code to send this message
-        # Check for however many sendline events we need (likely 17)
-        # self.mock_logger.assert_called_with(
-        #     LogLevel.NORMAL, Regex(r".*L2.*sendline.*")
-        # )
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
 
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(LogLevel.NORMAL, r".*busop.*(rwim|4).*", 16)

--- a/tests/integration/test_l1_write_request.py
+++ b/tests/integration/test_l1_write_request.py
@@ -1,0 +1,254 @@
+import re
+import unittest
+from callee import Regex
+from common.constants import MESIState, LogLevel, TraceCommand
+from utils.event_handler import handle_event
+from tests.integration.integration_setup import IntegrationSetup
+
+
+class TestCommandL1WriteRequest(IntegrationSetup):
+
+    def setUp(self):
+        super().setUp()
+        self.trace_event = TraceCommand.L1_DATA_WRITE
+        # nohit_addr is an address that results in a simulated
+        # NOHIT snoop response from other caches
+        self.nohit_addr = self.nohit_addresses[0]
+        # hit_addr is an address that results in a simulated
+        # HIT snoop response from other caches
+        self.hit_addr = self.hit_addresses[0]
+        # hitm_addr is an address that results in a simulated
+        # HITM snoop response from other caches
+        self.hitm_addr = self.hitm_addresses[0]
+
+    def test_exclusive(self):
+        """
+        Test writing a line in the Exclusive state.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss)
+        - Write same line (cache hit)
+        """
+        # Event 0: Read miss at self.nohit_addr (gets line in E state)
+        handle_event(self.cache, TraceCommand.L1_DATA_READ, self.nohit_addr)
+
+        # Confirm the L2 sendline message was issued for L1 request
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+
+        self.check_line_state(self.nohit_addr, MESIState.EXCLUSIVE)
+
+        # Event 1: Write hit at self.nohit_addr (should move to M state)
+        handle_event(self.cache, self.trace_event, self.nohit_addr)
+        self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
+
+        # The second read event should not generate a bus operation, because
+        # it was a hit to an exclusive line. So we'll test that there's only
+        # been 1 of these bus operations issued in total.
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*busop.*(read|1).*")
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 1)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 1)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_modified(self):
+        """
+        Test writing a line in the Modified state.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Write line (cache miss)
+        - Write same line (cache hit)
+        """
+        # Event 1: Write miss at self.nohit_addr (gets line in M state)
+        handle_event(self.cache, self.trace_event, self.nohit_addr)
+
+        # Confirm the RWIM bus op was issued
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
+
+        # Confirm the L2 sendline message was issued for L1 request
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+
+        self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
+
+        # Event 1: Write hit at self.nohit_addr (should stay in M state)
+        handle_event(self.cache, self.trace_event, self.nohit_addr)
+        self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
+
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
+
+        # TODO: Decide whether or not we want to assert additional busops
+        # have *not* been issued, or if this one is even of value.
+        self.assert_log_called_with_count(
+            LogLevel.NORMAL, r"busop.*(write|2).*address.*", 0
+        )
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 0)
+        self.assertEqual(self.cache.statistics.cache_writes, 2)
+        self.assertEqual(self.cache.statistics.cache_hits, 1)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_shared(self):
+        """
+        Test writing a line in the Shared state.
+        Other caches return a HIT snoop response.
+
+        Requires the following sequence:
+        - Read line (cache miss)
+        - Write line (cache hit)
+        """
+        # Event 0: Read miss at self.hit_addr (gets line in S state)
+        handle_event(self.cache, TraceCommand.L1_DATA_READ, self.hit_addr)
+        self.check_line_state(self.hit_addr, MESIState.SHARED)
+
+        # Event 1: Write hit at self.hit_addr (should move to M state)
+        handle_event(self.cache, self.trace_event, self.hit_addr)
+        self.check_line_state(self.hit_addr, MESIState.MODIFIED)
+
+        # Confirm the INVALIDATE bus op was issued
+        self.assert_log_called_with_count(
+            LogLevel.NORMAL, r"busop.*(invalidate|3).*", 1
+        )
+
+        # Confirm the L2 sendline message was issued for each L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
+
+        # Only the first read request should have resulted in a READ bus operation.
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*busop.*(read|1).*address")
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 1)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 1)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_hitm(self):
+        """
+        Test writing a line that's been modified in another cache.
+        Other caches return a HITM snoop response.
+
+        Requires the following sequence:
+        - Write line (cache miss, snarf from other cache flushWB)
+        """
+        # Event 1: Write miss at self.hitm_addr (gets line in M state)
+        # Assumes cache with the modified line flushes the line
+        # (with write-back) and our cache snarfs it
+        handle_event(self.cache, self.trace_event, self.hitm_addr)
+        self.check_line_state(self.hitm_addr, MESIState.MODIFIED)
+
+        # Confirm the L2 sendline message was issued for L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 1)
+
+        # Confirm the RWIM bus op was issued
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 0)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_hit(self):
+        """
+        Test writing a line that's in a S or E state in another cache.
+        Other cache(s) return a HIT snoop response.
+
+        Requires the following sequence:
+        - Write line (cache hit)
+        """
+        # Event 1: Write hit at self.hit_addr (should move to M state)
+        handle_event(self.cache, self.trace_event, self.hit_addr)
+        self.check_line_state(self.hit_addr, MESIState.MODIFIED)
+
+        # Confirm the L2 sendline message was issued for L1 request
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 1)
+
+        # Confirm the RWIM bus op was issued
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 0)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 1)
+
+    def test_clean_eviction(self):
+        """
+        Test writing a line that causes an eviction of a clean line.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Read lines to fill the cache (cache misses)
+        - Write line to cause an eviction (cache miss)
+        """
+        # Base addr that returns a NOHIT snoop response from other caches
+        address = 0x00000002  # Start with set 0, offset with NOHIT response
+        increment = 0x100000  # 1 MiB increment to change the tag
+
+        # Fill the cache
+        for _i in range(16):
+            address += increment
+            handle_event(self.cache, TraceCommand.L1_DATA_READ, address)
+            self.check_line_state(address, MESIState.EXCLUSIVE)
+
+        # One write to trigger an eviction of a clean line
+        handle_event(self.cache, self.trace_event, address + increment)
+
+        # Confirm the L2 sendline message was issued for each L1 request (reads and write)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+
+        # Check for one READ bus operation per cache miss
+        self.assert_log_called_with_count(
+            LogLevel.NORMAL, r".*busop.*(read|1).*address", 16
+        )
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 16)
+        self.assertEqual(self.cache.statistics.cache_writes, 1)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 17)
+
+    def test_dirty_eviction(self):
+        """
+        Test writing a line that causes an eviction of a dirty line.
+        Other caches return a NOHIT snoop response.
+
+        Requires the following sequence:
+        - Write lines to fill the cache (cache misses)
+        - Write line to cause an eviction (cache miss)
+        """
+        # Base addr that returns a NOHIT snoop response from other caches
+        address = 0x00000002  # Start with set 0, offset with NOHIT response
+        increment = 0x100000  # 1 MiB increment to change the tag
+
+        # Fill the cache
+        for _i in range(16):
+            address += increment
+            handle_event(self.cache, 1, address)
+            self.check_line_state(address, MESIState.MODIFIED)
+
+        # One write to trigger an eviction of a clean line
+        handle_event(self.cache, self.trace_event, address + increment)
+
+        # Confirm the L2 sendline message was issued for each L1 request (reads and write)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+
+        # Check for one READ bus operation per cache miss
+        self.assert_log_called_with_count(
+            LogLevel.NORMAL, r".*busop.*(rwim|4).*address", 17
+        )
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 0)
+        self.assertEqual(self.cache.statistics.cache_writes, 17)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 17)
+
+
+# Allow direct execution of this file
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds integration tests for event 1 - L1 write request, and does some finalization of other L1 request tests.

* Enables the `SENDLINE` checks in the L1 read request tests
* Moves `SENDLINE` events from MESI controller to cache, in order to get tests for L1 write requests working
* Adds L1 write request tests

The following command will run the 7 tests for event 1:
```sh
PYTHONPATH=./src python -m unittest tests.integration.test_l1_write_request
```