### PR TITLE
Add checks for eviction-related messages in tests

### DIFF
--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -276,6 +276,9 @@ class Cache:
             message_to_l1_cache(CacheMessage.EVICTLINE, address)
             # Perform writeback for modified data
             bus_operation(BusOp.WRITE, address)
+        else:
+            # Ensure L1 evicts line to maintain inclusivity
+            message_to_l1_cache(CacheMessage.EVICTLINE, address)
 
     def lookup_line(self, address: int) -> Optional[CacheLine]:
         """

--- a/tests/integration/test_l1_read_request.py
+++ b/tests/integration/test_l1_read_request.py
@@ -198,6 +198,9 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(LogLevel.NORMAL, r".*busop.*(read|1).*", 17)
 
+        # Confirm the L2 message to L1 for evictline was issued
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 17)
         self.assertEqual(self.cache.statistics.cache_writes, 0)
@@ -236,6 +239,10 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         self.assert_log_called_with_count(
             LogLevel.NORMAL, r".*busop.*(read|1).*address", 1
         )
+
+        # Confirm the L2 messages to L1 for eviction were issued
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*getline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 1)

--- a/tests/integration/test_l1_write_request.py
+++ b/tests/integration/test_l1_write_request.py
@@ -1,6 +1,4 @@
-import re
 import unittest
-from callee import Regex
 from common.constants import MESIState, LogLevel, TraceCommand
 from utils.event_handler import handle_event
 from tests.integration.integration_setup import IntegrationSetup

--- a/tests/integration/test_l1_write_request.py
+++ b/tests/integration/test_l1_write_request.py
@@ -206,6 +206,9 @@ class TestCommandL1WriteRequest(IntegrationSetup):
             LogLevel.NORMAL, r".*busop.*(read|1).*address", 16
         )
 
+        # Confirm the L2 message to L1 for evictline was issued
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 16)
         self.assertEqual(self.cache.statistics.cache_writes, 1)
@@ -241,6 +244,10 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         self.assert_log_called_with_count(
             LogLevel.NORMAL, r".*busop.*(rwim|4).*address", 17
         )
+
+        # Confirm the L2 messages to L1 for eviction were issued
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*getline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 0)


### PR DESCRIPTION
Updates the cache victim line handling to send a message to L1 to evict a clean victim line

Opening this as a draft for now, until we get confirmation on whether this should be EVICTLINE vs INVALIDATELINE