### PR TITLE
Updating cache printing to match project guidelines

### DIFF
--- a/src/cache/bus_interface.py
+++ b/src/cache/bus_interface.py
@@ -29,7 +29,7 @@ class BusInterface:
         snoop_result = self.get_snoop_result(address)
         self.logger.log(
             LogLevel.NORMAL,
-            f"BusOp: {bus_op.value}, Address: {address:08x}, Snoop Result: {snoop_result.value}",
+            f"BusOp: {bus_op.value}, Address: 0x{address:08X}, Snoop Result: {snoop_result.value}",
         )
 
     def get_snoop_result(self, address: int) -> SnoopResult:
@@ -56,7 +56,7 @@ class BusInterface:
         """Report our snoop result for operations from other caches"""
         self.logger.log(
             LogLevel.NORMAL,
-            f"SnoopResult: Address {address:08x}, SnoopResult: {snoop_result.value}",
+            f"SnoopResult: Address 0x{address:08X}, SnoopResult: {snoop_result.value}",
         )
 
 

--- a/src/cache/bus_interface.py
+++ b/src/cache/bus_interface.py
@@ -29,7 +29,7 @@ class BusInterface:
         snoop_result = self.get_snoop_result(address)
         self.logger.log(
             LogLevel.NORMAL,
-            f"BusOp: {bus_op.name}, Address: {address:08x}, Snoop Result: {snoop_result.name}",
+            f"BusOp: {bus_op.value}, Address: {address:08x}, Snoop Result: {snoop_result.value}",
         )
 
     def get_snoop_result(self, address: int) -> SnoopResult:
@@ -56,7 +56,7 @@ class BusInterface:
         """Report our snoop result for operations from other caches"""
         self.logger.log(
             LogLevel.NORMAL,
-            f"SnoopResult: Address {address:08x}, SnoopResult: {snoop_result.name}",
+            f"SnoopResult: Address {address:08x}, SnoopResult: {snoop_result.value}",
         )
 
 

--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -318,6 +318,11 @@ class Cache:
     def print_cache(self):
         """Print cache contents of only valid lines using the logger, this is in response to trace command 9"""
         header_printed = False
+        # ANSI Color
+        YELLOW = "\033[33m"
+        RESET = "\033[0m"
+        # Width of PLRU bits
+        plru_width = self.associativity - 1
 
         for index, cache_set in enumerate(self.sets):
             if cache_set is not None:
@@ -326,20 +331,23 @@ class Cache:
                 if valid_lines:  # If there are valid lines to print
                     if not header_printed:
                         header = (
-                            "\n-----------------------------"
-                            "\nWay  | Tag      | MESI State|"
+                            "-----------------------------"
+                            "\nWay  | Tag     | MESI State |"
                             "\n-----------------------------"
                         )
                         self.logger.log(LogLevel.SILENT, header)
                         header_printed = True
                     self.logger.log(
-                        LogLevel.SILENT, f"\nValid Lines in Set 0x{index:08x}"
+                        LogLevel.SILENT,
+                        f"Valid Lines in Set {YELLOW}0x{index:08x}{RESET}",
                     )
                     self.logger.log(
-                        LogLevel.SILENT, f"PLRU State Bits: {cache_set.state:b}"
+                        LogLevel.SILENT,
+                        f"PLRU State Bits: {cache_set.state:0{plru_width}b}",
                     )
                     self.logger.log(LogLevel.SILENT, "-----------------------------")
                     self.logger.log(LogLevel.SILENT, valid_lines)
+                    self.logger.log(LogLevel.SILENT, "-----------------------------")
 
     @property
     def __config_str(self) -> str:
@@ -357,3 +365,6 @@ Address Bits:
     Index: {self.index_bits}
     Byte Select: {self.byte_select_bits}
 """
+
+    def print_stats(self) -> None:
+        self.statistics.print_stats()

--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -332,14 +332,14 @@ class Cache:
                     if not header_printed:
                         header = (
                             "-----------------------------"
-                            "\nWay  | Tag     | MESI State |"
+                            "\nWay  | Tag   | MESI State |"
                             "\n-----------------------------"
                         )
                         self.logger.log(LogLevel.SILENT, header)
                         header_printed = True
                     self.logger.log(
                         LogLevel.SILENT,
-                        f"Valid Lines in Set {YELLOW}0x{index:08x}{RESET}",
+                        f"Valid Lines in Set {YELLOW}0x{index:08X}{RESET}",
                     )
                     self.logger.log(
                         LogLevel.SILENT,

--- a/src/cache/cache_set.py
+++ b/src/cache/cache_set.py
@@ -302,7 +302,7 @@ class CacheSetPLRUMESI:
         if all(line.is_invalid() for line in self.ways):
             return  # Empty set
 
-        line_format = "{:3d}  | 0x{:03x} | {:9s} |"
+        line_format = "{:3d}  | 0x{:03X} | {:9s}  |"
         valid_lines = []
 
         for way_index, line in enumerate(self.ways):

--- a/src/cache/cache_set.py
+++ b/src/cache/cache_set.py
@@ -302,7 +302,7 @@ class CacheSetPLRUMESI:
         if all(line.is_invalid() for line in self.ways):
             return  # Empty set
 
-        line_format = "{:3d}  | 0x{:06x} | {:9s} |"
+        line_format = "{:3d}  | 0x{:03x} | {:9s} |"
         valid_lines = []
 
         for way_index, line in enumerate(self.ways):

--- a/src/cache/l1_interface.py
+++ b/src/cache/l1_interface.py
@@ -29,9 +29,7 @@ class L1Interface:
 
     def message_to_cache(self, message: CacheMessage, address: int) -> None:
         """Send control message to L1 cache"""
-        self.logger.log(
-            LogLevel.NORMAL, f"L2: {message.name}, Address: 0x{address:08X}"
-        )
+        self.logger.log(LogLevel.NORMAL, f"L2: {message.value:<3} 0x{address:08X}")
 
 
 def message_to_l1_cache(message: CacheMessage, address: int) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -46,6 +46,7 @@ def main():
                     f"\nOperation: {op.value} {op.name:20} Address: {addr_str}",
                 )
                 handle_event(cache, op.value, addr)
+                cache.print_stats()
 
     # Log a meaningful message and re-raise error to exit the program
     # with a non-zero exit code

--- a/src/utils/statistics.py
+++ b/src/utils/statistics.py
@@ -49,19 +49,24 @@ class Statistics:
         self.cache_misses += 1
 
     def print_stats(self, stream: TextIO = sys.stdout):
-        """Print formatted cache statistics to specified stream
-        Args:
-            stream (TextIO): Output stream (defaults to sys.stdout)
-        """
-        stats = f"""
-----------------------------------
-          Cache Statistics
-----------------------------------
-  Number of cache reads:  {self.cache_reads:<10}
-  Number of cache writes: {self.cache_writes:<10}
-  Number of cache hits:   {self.cache_hits:<10}
-  Number of cache misses: {self.cache_misses:<10}
-  Cache hit ratio:        {self.cache_hit_ratio:<9.5%}
-----------------------------------
-"""
-        print(stats, file=stream, flush=True)  # flush avoids buffered output
+        """Print formatted cache statistics to specified stream"""
+        # Basic ANSI color codes
+        BLUE = "\033[34m"
+        GREEN = "\033[32m"
+        YELLOW = "\033[33m"
+        RED = "\033[31m"
+        BOLD = "\033[1m"
+        RESET = "\033[0m"
+
+        DIVIDER = f"{BOLD}|{RESET}"
+
+        stats = (
+            f"{BOLD}Cache Stats: {RESET} "
+            f"Reads: {BLUE}{self.cache_reads:<2}{RESET} "
+            f"Writes: {BLUE}{self.cache_writes:<2}{RESET} {DIVIDER} "
+            f"Hits: {GREEN}{self.cache_hits:<2}{RESET} "
+            f"Misses: {RED}{self.cache_misses:<2}{RESET} {DIVIDER} "
+            f"Hit Ratio: {YELLOW}{self.cache_hit_ratio:.1%}{RESET}\n"
+        )
+
+        print(stats, file=stream, flush=True)

--- a/tests/integration/test_l1_read_request.py
+++ b/tests/integration/test_l1_read_request.py
@@ -46,7 +46,7 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.nohit_addr)
 
         # Confirm the L2 sendline message was issued
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (sendline|2).*")
 
         # Check that a bus operation was issued, once per read event
         # with either the name (read) or the operation ID number
@@ -99,7 +99,7 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 3)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 3)
 
         # Only the first read request should have resulted in a READ
         # bus operation.
@@ -132,7 +132,7 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         self.check_line_state(self.hit_addr, MESIState.SHARED)
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 2)
 
         # Only the first read request should have resulted in a READ
         # bus operation.
@@ -159,7 +159,7 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         self.check_line_state(self.hitm_addr, MESIState.SHARED)
 
         # Confirm the L2 sendline message was issued
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (sendline|2).*")
 
         # Check for a single READ bus operation
         self.assert_log_called_once_with(LogLevel.NORMAL, r".*busop.*(read|1).*")
@@ -193,13 +193,13 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address + increment)
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 17)
 
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(LogLevel.NORMAL, r".*busop.*(read|1).*", 17)
 
         # Confirm the L2 message to L1 for evictline was issued
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (evictline|4).*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 17)
@@ -230,7 +230,7 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address + increment)
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 17)
 
         # Check for one RWIM bus operation per cache miss
         self.assert_log_called_with_count(LogLevel.NORMAL, r".*busop.*(rwim|4).*", 16)
@@ -241,8 +241,8 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         )
 
         # Confirm the L2 messages to L1 for eviction were issued
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*getline.*", 1)
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (getline|1).*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (evictline|4).*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 1)

--- a/tests/integration/test_l1_write_request.py
+++ b/tests/integration/test_l1_write_request.py
@@ -32,7 +32,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         handle_event(self.cache, TraceCommand.L1_DATA_READ, self.nohit_addr)
 
         # Confirm the L2 sendline message was issued for L1 request
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (sendline|2).*")
 
         self.check_line_state(self.nohit_addr, MESIState.EXCLUSIVE)
 
@@ -67,7 +67,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
 
         # Confirm the L2 sendline message was issued for L1 request
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*sendline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (sendline|2).*")
 
         self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
 
@@ -76,7 +76,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         self.check_line_state(self.nohit_addr, MESIState.MODIFIED)
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 2)
 
         # TODO: Decide whether or not we want to assert additional busops
         # have *not* been issued, or if this one is even of value.
@@ -113,7 +113,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         )
 
         # Confirm the L2 sendline message was issued for each L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 2)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 2)
 
         # Only the first read request should have resulted in a READ bus operation.
         self.assert_log_called_once_with(LogLevel.NORMAL, r".*busop.*(read|1).*address")
@@ -139,7 +139,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         self.check_line_state(self.hitm_addr, MESIState.MODIFIED)
 
         # Confirm the L2 sendline message was issued for L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 1)
 
         # Confirm the RWIM bus op was issued
         self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
@@ -163,7 +163,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         self.check_line_state(self.hit_addr, MESIState.MODIFIED)
 
         # Confirm the L2 sendline message was issued for L1 request
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 1)
 
         # Confirm the RWIM bus op was issued
         self.assert_log_called_once_with(LogLevel.NORMAL, r"busop.*(rwim|4).*")
@@ -197,7 +197,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address + increment)
 
         # Confirm the L2 sendline message was issued for each L1 request (reads and write)
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 17)
 
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(
@@ -205,7 +205,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         )
 
         # Confirm the L2 message to L1 for evictline was issued
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (evictline|4).*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 16)
@@ -236,7 +236,7 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address + increment)
 
         # Confirm the L2 sendline message was issued for each L1 request (reads and write)
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*sendline.*", 17)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (sendline|2).*", 17)
 
         # Check for one READ bus operation per cache miss
         self.assert_log_called_with_count(
@@ -244,8 +244,8 @@ class TestCommandL1WriteRequest(IntegrationSetup):
         )
 
         # Confirm the L2 messages to L1 for eviction were issued
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*getline.*", 1)
-        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2.*evictline.*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (getline|1).*", 1)
+        self.assert_log_called_with_count(LogLevel.NORMAL, r"l2: (evictline|4).*", 1)
 
         # Assertions for statistics
         self.assertEqual(self.cache.statistics.cache_reads, 0)

--- a/tests/integration/test_snooped_invalidate_command.py
+++ b/tests/integration/test_snooped_invalidate_command.py
@@ -26,8 +26,8 @@ class TestCommandSnoopedInvalidate(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address)   # HIT
 
         # Updated regex patterns to match actual output
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*invalidateline.*")
-        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult*.*hit*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (invalidateline|3).*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult*.*(hit|1)*")
 
     def test_snoop_invalidate_clean_shared_line(self):
         """
@@ -41,8 +41,8 @@ class TestCommandSnoopedInvalidate(IntegrationSetup):
 
         handle_event(self.cache, self.trace_event, address)   # HIT
 
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*invalidateline.*")
-        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult*.*hit*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (invalidateline|3).*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult*.*(hit|1)*")
 
     def test_snoop_invalidate_dirty_line(self):
         """
@@ -55,13 +55,13 @@ class TestCommandSnoopedInvalidate(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address)   # HITM
 
         # Checks the our cache puts the snoop result
-        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult.*hitm.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult.*(hitm|2).*")
         # Chcek that we are getting most recent data from L1
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*getline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (getline|1).*")
         # Check that we then invalidate line in L1
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*invalidateline.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (invalidateline|3).*")
         # Check that we are performing a writeback
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"BusOp.*write.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"BusOp: (write|2).*")
         # Check that our cache no longer has the data
         self.check_line_state(address, MESIState.INVALID)
 
@@ -78,7 +78,7 @@ class TestCommandSnoopedInvalidate(IntegrationSetup):
         handle_event(self.cache, self.trace_event, address + increment) # MISS
 
         # Check that we are not doing anything except putting the snoop result
-        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult.*nohit.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r".*snoopresult.*(nohit|0).*")
         self.check_line_state(address, MESIState.EXCLUSIVE) 
 
     

--- a/tests/integration/test_snooped_read_request.py
+++ b/tests/integration/test_snooped_read_request.py
@@ -58,12 +58,12 @@ class TestSnoopedReadRequest(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.nohit_addr)
 
         # Confirm our cache put the snoop result on the bus and updated state
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"snoopresult.*(hitm|4)")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"snoopresult.*(hitm|2)")
         self.check_line_state(self.nohit_addr, MESIState.SHARED)
 
         # Confirm our cache retrieved the line from L1 and wrote it back
         # We assume the reading cache can snarf it
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*(getline|1).*address.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (getline|1).*")
         self.assert_log_called_once_with(
             LogLevel.NORMAL, r"busop.*(write|2).*address.*"
         )

--- a/tests/integration/test_snooped_rwim_request.py
+++ b/tests/integration/test_snooped_rwim_request.py
@@ -58,12 +58,12 @@ class TestSnoopedRWIMRequest(IntegrationSetup):
         handle_event(self.cache, self.trace_event, self.nohit_addr)
 
         # Confirm our cache put the snoop result on the bus and updated state
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"snoopresult.*(hitm|4)")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"snoopresult.*(hitm|2)")
         self.check_line_state(self.nohit_addr, MESIState.INVALID)
 
         # Confirm our cache retrieved the line from L1 and wrote it back
         # We assume the RWIM cache can snarf it
-        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2.*(getline|1).*address.*")
+        self.assert_log_called_once_with(LogLevel.NORMAL, r"l2: (getline|1).*")
         self.assert_log_called_once_with(
             LogLevel.NORMAL, r"busop.*(write|2).*address.*"
         )


### PR DESCRIPTION
Main changes are: 
- Enums print `enum.value` instead of `enum.name`
- Cache statistics are printed after each trace
- Added color output in a couple of areas to ease reading, for example:
![image](https://github.com/user-attachments/assets/204cbcb8-f361-4a81-8760-d92d068cd652)
