### PR TITLE
Add option to read trace file in chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 
 # Ignore editor-specific settings
 .vscode/
+
+# Ignore large trace files
+src/data/large*.txt

--- a/scripts/generate_trace_files.py
+++ b/scripts/generate_trace_files.py
@@ -1,0 +1,46 @@
+def generate_files() -> None:
+    """
+    Generate large files to test our cache simulation program with.
+    These files will not be checked in to the repo, because they are
+    too large, and there is no need if they are dynamically created
+    in a reasonable amount of time.
+
+    Generates the following:
+    - large_read.txt: Read events for one sixteenth of all addresses
+      Should result in 2^23 read events, and 2^23 cache misses,
+      no writes, no hits.
+      Contains 8388608 lines.
+    - large_read_write.txt: Read events for 1 Mi addresses, then
+      read and write half of them again.
+      Should result in 1.5 Mi read events, 2^20 misses, 2^10 hits, 512 Ki writes;
+      50% hit rate.
+      Contains 2097152 lines.
+    """
+    with open("src/data/large_read.txt", "w") as f:
+        # Go through all possible addresses, stepping by 512 bytes
+        # to target a new cache set and line with each request
+        for i in range(0, 2**32, 512):
+            # Format second column as hexadecimal with no leading '0x'
+            hex_value = hex(i).lstrip("0x") or "0"
+            f.write(f"0 {hex_value}\n")
+
+    with open("src/data/large_read_write.txt", "w") as f:
+        # Go through all possible addresses, stepping by 2^12 bytes
+        # to target a new cache set and line with each request
+        step = 1 << 12
+        for i in range(0, 2**32, step):
+            # Format second column as hexadecimal with no leading '0x'
+            hex_value = hex(i).lstrip("0x") or "0"
+            f.write(f"0 {hex_value}\n")
+            # Every other iteration, add another read and write
+            if (i // step) % 2 == 0:
+                f.write(f"1 {hex_value}\n")
+                f.write(f"0 {hex_value}\n")
+
+
+def main():
+    generate_files()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -35,8 +35,7 @@ def main():
 
     try:
         with TraceFileParser(args.file) as parser:
-            while True:
-                result = parser.read_line()
+            for result in parser.read_in_chunks():
                 if result is None:
                     break
                 op, addr = result

--- a/tests/integration/test_l1_read_request.py
+++ b/tests/integration/test_l1_read_request.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 from callee import Regex
-from common.constants import MESIState, LogLevel
+from common.constants import MESIState, LogLevel, TraceCommand
 from utils.event_handler import handle_event
 from tests.integration.integration_setup import IntegrationSetup
 
@@ -249,6 +249,17 @@ class TestCommandL1ReadRequestData(IntegrationSetup):
         self.assertEqual(self.cache.statistics.cache_writes, 16)
         self.assertEqual(self.cache.statistics.cache_hits, 0)
         self.assertEqual(self.cache.statistics.cache_misses, 17)
+
+    def test_read_all_in_set(self):
+        # Read all tags in the set
+        for address in range(0x00000000, 0xFFF00001, 0x00100000):
+            handle_event(self.cache, TraceCommand.L1_DATA_READ, address)
+
+        # Assertions for statistics
+        self.assertEqual(self.cache.statistics.cache_reads, 1 << 12)
+        self.assertEqual(self.cache.statistics.cache_writes, 0)
+        self.assertEqual(self.cache.statistics.cache_hits, 0)
+        self.assertEqual(self.cache.statistics.cache_misses, 1 << 12)
 
 
 # In order to test events 0 and 2, we need to create a child class for


### PR DESCRIPTION
@reecewayt I was wondering if you'd want to try this out and see if it speeds up processing the large example file we have. Both the original and the new option run in about the same time on my machine, I think the bottleneck here being the actual output. But I wasn't sure if this might help on your laptop. I was also wondering if you were running it inside WSL, in which case it might be slower than running directly on the host.

If it results in a noticeable speedup, I can clean up the code and open a non-draft PR.