### PR TITLE
Fixup location of cache stats printing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -46,7 +46,8 @@ def main():
                     f"\nOperation: {op.value} {op.name:20} Address: {addr_str}",
                 )
                 handle_event(cache, op.value, addr)
-                cache.print_stats()
+
+        cache.print_stats()
 
     # Log a meaningful message and re-raise error to exit the program
     # with a non-zero exit code

--- a/src/utils/statistics.py
+++ b/src/utils/statistics.py
@@ -66,7 +66,7 @@ class Statistics:
             f"Writes: {BLUE}{self.cache_writes:<2}{RESET} {DIVIDER} "
             f"Hits: {GREEN}{self.cache_hits:<2}{RESET} "
             f"Misses: {RED}{self.cache_misses:<2}{RESET} {DIVIDER} "
-            f"Hit Ratio: {YELLOW}{self.cache_hit_ratio:.1%}{RESET}\n"
+            f"Hit Ratio: {YELLOW}{self.cache_hit_ratio:.1%}{RESET}"
         )
 
         print(stats, file=stream, flush=True)


### PR DESCRIPTION
Got clarification that a trace refers to the entire sequence, not a single trace event, so moving the printing of stats to after the file has been processed.