### PR TITLE
add a check in the trace parser to throw a warn in too many tokens 

### DIFF
--- a/src/utils/trace_parser.py
+++ b/src/utils/trace_parser.py
@@ -178,6 +178,11 @@ class TraceFileParser:
             warnings.warn(f"Invalid line format: {line}")
             return None
 
+        # Check that there aren't too many tokens in line
+        if len(parts) > 2:
+            warnings.warn(f"Invalid line format (too many tokens): {line}")
+            return None
+
         # Handle commands without an address
         if op in (TraceCommand.CLEAR_CACHE, TraceCommand.PRINT_CACHE):
             return op, None


### PR DESCRIPTION
Added an additional check in trace_parser.py to throw an error if the line contains too many tokens. 